### PR TITLE
Feature/infix in operator

### DIFF
--- a/gen_spec_with_ghost.c
+++ b/gen_spec_with_ghost.c
@@ -2,13 +2,13 @@
 
 /*@ assigns forbidden;
   @ ensures ! \subset(\result,\old(forbidden))
-  @   && \subset(\result,forbidden)
+  @   && \result \in forbidden
       && \subset(\old(forbidden),forbidden);
   @*/
 int gen() {
   static int x = 0;
   /*@ global invariant I: \forall integer k;
-    @    \subset(k,forbidden) ==> x > k;
+    @    k \in forbidden ==> x > k;
     @*/
   x++;
   //@ ghost forbidden = \union(x,forbidden);

--- a/gen_spec_with_model.c
+++ b/gen_spec_with_model.c
@@ -3,7 +3,7 @@
 //@ model set<integer> forbidden = \empty;
 
 /*@ assigns forbidden;
-  @ ensures ! \subset(\result,\old(forbidden))
-  @   && \subset(\result,forbidden) && \subset(\old(forbidden),forbidden);
+  @ ensures ! (\result \in \old(forbidden))
+  @   && \result \in forbidden && \subset(\old(forbidden),forbidden);
   @*/
 int gen();

--- a/loc.tex
+++ b/loc.tex
@@ -17,6 +17,7 @@
        | term ; implicit singleton
        \
   pred ::= "\subset" "(" tset "," tset ")" ; set inclusion
+       | term "\in" tset ; set membership
 \end{syntax}
 
 %%% Local Variables:

--- a/main.tex
+++ b/main.tex
@@ -235,7 +235,13 @@ as much as possible of ACSL.
 
 \section{Changes}
 
-\subsection{Version 1.12}
+\subsection{Version 1.13} % ?
+\begin{itemize}
+\item New infix predicate \lstinline|\in| for set membership
+  (section~\ref{sec:locations})
+\end{itemize}
+
+\subsection{Version 1.12} % sulfur
 \begin{itemize}
 \item Fixes syntax rule for statement contracts in allowing completeness clauses
   (figure~\ref{fig:gram:stcontracts})

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -1249,6 +1249,9 @@ elements \lstinline|t$_1$|, $\ldots$, \lstinline|t$_n$|.
   value \lstinline|b| of binders
   satisfying predicate \lstinline|P|
   (binders \lstinline|b| are bound in both \lstinline|s| and \lstinline|P|).
+\item \lstinline|x \in s| holds if and only if is an element of s.
+\item \lstinline|\subset(s$_1$,s$_2$)| holds if and only if each element
+  of \lstinline|s$_1$| is also an element of \lstinline|s$_2$|.
 \end{itemize}
 
 Note that \lstinline|assigns \nothing| is equivalent to

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -25,6 +25,8 @@ must be noted.
       \hline
       \lstinline|<| & \ensuremath{<} & 0x003C \\
       \hline
+      \lstinline|\in| & \ensuremath{\in} & 0x2208 \\
+      \hline
       \lstinline|!=| & \ensuremath{\not\equiv} & 0x2262 \\
       \hline
       \lstinline|==| & \ensuremath{\equiv} & 0x2261 \\


### PR DESCRIPTION
Add an explicit set membership operator.

Remaining tasks:

- [x] brief indication of its semantics
- [x] Propose an unicode equivalent symbol (∈ a.k.a U+2208 element of)?