### PR TITLE
Fix and clarify clauses and restrictions about \old and \result

### DIFF
--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -936,10 +936,19 @@ constructs (shown in Figure~\ref{fig:gram:oldandresult}).
   predicate or term \lstinline|e| in the pre-state of the function.
 \item \result\indexttbs{result} denotes the returned value of the function.
 \end{itemize}
-\lstinline|\old(e)| and \result{} can be used only in \ensures{} clauses, since
-the other clauses already refer to the pre-state. In addition,
-\result{} can not be used in the contract of a function that returns
+\lstinline|\old(e)| can be used only in \ensures{}, \assigns{},
+\allocates{} and \frees{} clauses, since
+the other clauses already refer to only one state, the pre-state.
+In addition, \result{} can not be used in the contract of a function that returns
 \void{}.
+
+%[Andre M.] START proposition:
+%\item in \assigns{} and \frees{} clauses, a \result{} not directly inside an
+%  \lstinline|\at(...,Post)| (either explicitly or implicitly) is forbidden.
+% Note: we must still be able to write assigns \result \from \nothing, so
+% the above must be refined.
+% END proposition
+
 
 C function parameters\index{formal parameter} are obtained by
 value from actual parameters that mostly remain unaltered by the
@@ -1598,9 +1607,12 @@ in fact syntactic sugar for \lstinline|\at(e,Old)|.
   where it refers to the state where the annotation appears; and in
   all contracts, where it refers to the pre-state for the
   \lstinline|requires|, \lstinline|assumes|, \lstinline|assigns|,
+  \lstinline|frees|,
   \lstinline|variant|,
   \lstinline|terminates|
-  clauses and the post-state for other clauses.
+  clauses and the post-state for other clauses
+  (\lstinline|ensures|, \lstinline|allocates|, and abrupt termination
+  clauses).
 It is also visible in data invariants, presented in Section~\ref{sec:invariants}.
 \item The label \lstinline|Old| is visible in \lstinline|assigns| and
   \lstinline|ensures| clauses of all contracts (both for functions and for


### PR DESCRIPTION
To allow you to more easily modify my patch, now that I have access to this repository, I'm using a branch instead of a fork. So I reverted the master in my fork, and apparently Github detected that no commits were available, so it automatically closed the PR (#40).

