### PR TITLE
adding \pi and \e notations

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -243,6 +243,7 @@ as much as possible of ACSL.
 \item New infix predicate \lstinline|\in| for set membership
   (section~\ref{sec:locations})
 \item Fixes some typing error for constructs rejecting \lstinline|void*| pointers (section~\ref{subsec:allocation-contract})
+\item Notations added for real numbers $\pi$ and $e$ (section~\ref{sec:floating-point})
 \end{itemize}
 
 \subsection{Version 1.12} % Sulfur

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -604,10 +604,12 @@ real \pow(real x, real y) ;
 integer \ceil(real x) ;
 integer \floor(real x) ;
 
+real \e ;
 real \exp(real x) ;
 real \log(real x) ;
 real \log10(real x) ;
 
+real \pi ;
 real \cos(real x) ;
 real \sin(real x) ;
 real \tan(real x) ;
@@ -623,6 +625,9 @@ real \atan(real x) ;
 real \atan2(real y, real x) ;
 real \hypot(real x, real y) ;
 \end{listing-nonumber}
+
+Notation \lstinline|\pi| refers to the real number $\pi$ and \lstinline|\e| to
+the base of the natural logarithm \lstinline|\log| (\lstinline|\log(\e)==1|).
 
 \subsubsection{Exact computations}
 


### PR DESCRIPTION
Adding the real number `\pi` and `\e` to the mathemacial built-ins. 