### PR TITLE
Adding an explanation for the use of the red color. Fixes !33.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ acsl.tex: $(MAIN).tex Makefile
 	@chmod a-w $@
 
 # Internal to Frama-C
-FRAMAC=../../bin/frama-c
+FRAMAC ?= ../../bin/frama-c
 
 HAS_FRAMAC:=$(shell if test -x $(FRAMAC); then echo yes; else echo no; fi)
 

--- a/intro_modern.tex
+++ b/intro_modern.tex
@@ -18,14 +18,14 @@ source code.
 
 \ifthenelse{\boolean{PrintImplementationRq}}{%
 Not all of the features mentioned in this document are currently
-implemented in the Frama-C kernel. Those who aren't yet are signaled
+implemented in the Frama-C kernel. Unimplemented features are signaled
 as in the following line:
 \begin{quote}
-\notimplemented[Additional remarks on the feature may appear as footnote]%
+\notimplemented[Additional remarks on the feature may appear in a footnote.]%
 {This feature is not currently supported by Frama-C}
 \end{quote}
 
-As a summary, the features that are not currently implemented into
+As a summary, the features that are not currently implemented in
 Frama-C include in particular:
 \begin{itemize}
 \item some built-in predicates and logical functions;

--- a/intro_modern.tex
+++ b/intro_modern.tex
@@ -3,13 +3,19 @@
 
 This document is a reference manual for
 \ifthenelse{\boolean{PrintImplementationRq}}%
-{the ACSL implementation provided by the Frama-C
-  framework~\cite{frama-c}.}%
-{ACSL.}
+           {the ACSL implementation\footnote{In this reference manual of ACSL,
+               text in red color is related to features that have not yet been
+               implemented in \textsc{Frama-C} \framacversion{}.}
+            provided by the \mbox{\textsc{Frama-C}} %no cesure
+            framework~\cite{frama-c}.}%
+           {ACSL.}
 ACSL is an acronym for ``ANSI/ISO C
 Specification Language''. This is a Behavioral Interface Specification
-Language (BISL) implemented in the \textsc{Frama-C} framework.
-It aims at specifying behavioral properties of C
+Language (BISL)
+\ifthenelse{\boolean{PrintImplementationRq}}%
+           {for}%
+           {implemented in the \textsc{Frama-C} framework. It aims at}
+specifying behavioral properties of C
 source code. The main inspiration for this language comes from the
 specification language of the \textsc{Caduceus}
 tool~\cite{filliatre04icfem,filliatre07cav} for deductive verification

--- a/intro_modern.tex
+++ b/intro_modern.tex
@@ -3,10 +3,8 @@
 
 This document is a reference manual for
 \ifthenelse{\boolean{PrintImplementationRq}}%
-           {the ACSL implementation\footnote{In this reference manual of ACSL,
-               text in red color is related to features that have not yet been
-               implemented in \textsc{Frama-C} \framacversion{}.}
-            provided by the \mbox{\textsc{Frama-C}} %no cesure
+           {the ACSL implementation provided by the
+             \mbox{\textsc{Frama-C}} %no cesure
             framework~\cite{frama-c}.}%
            {ACSL.}
 ACSL is an acronym for ``ANSI/ISO C
@@ -16,7 +14,33 @@ Language (BISL)
            {for}%
            {implemented in the \textsc{Frama-C} framework. It aims at}
 specifying behavioral properties of C
-source code. The main inspiration for this language comes from the
+source code.
+
+\ifthenelse{\boolean{PrintImplementationRq}}{%
+Not all of the features mentioned in this document are currently
+implemented in the Frama-C kernel. Those who aren't yet are signaled
+as in the following line:
+\begin{quote}
+\notimplemented[Additional remarks on the feature may appear as footnote]%
+{This feature is not currently supported by Frama-C}
+\end{quote}
+
+As a summary, the features that are not currently implemented into
+Frama-C include in particular:
+\begin{itemize}
+\item some built-in predicates and logical functions;
+\item definition of logical types (section~\ref{sec:logicspec});
+\item specification modules (section~\ref{sec:specmodules});
+\item model variables (section~\ref{ex:model});
+\item only basic support for ghost code is provided (section~\ref{sec:ghost});
+\item verification of non interference of ghost code
+  (p.~\pageref{sec:semantics-ghost-code});
+\item specification of volatile variables
+  (section~\ref{sec:volatile-variables});
+\end{itemize}
+}%
+
+The main inspiration for this language comes from the
 specification language of the \textsc{Caduceus}
 tool~\cite{filliatre04icfem,filliatre07cav} for deductive verification
 of behavioral properties of C programs. The specification language of


### PR DESCRIPTION
That modifies the first paragraph of the introduction in a such way that gives  for
- the reference manual:

_This document is a reference manual for ACSL. ACSL is an acronym for “ANSI/ISO C
Specification Language”. This is a Behavioral Interface Specification Language (BISL) implemented
in the Frama-C framework. It aims at specifying behavioral properties of C
source code._

- the implementation  manual:

_This document is a reference manual for the ACSL implementation*1 provided by the
Frama-C framework [13]. ACSL is an acronym for “ANSI/ISO C Specification Language”.
This is a Behavioral Interface Specification Language (BISL) for specifying behavioral
properties of C source code._

with the foot note:

_*1 In this reference manual of ACSL, text in red color is related to features that have not yet been
implemented in Frama-C Sulfur-20171101+dev ._
