### PR TITLE
Removing LaTeX \margingpar about abrupt termination and `loop assigns`.

### DIFF
--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -1763,7 +1763,8 @@ The locations having their values modified during the path execution, starting
 at the beginning of the annotated statement and leading
 to a \lstinline|goto| jumping out of it, should be part of its 
 \assigns clause.
-\marginpar{This behavior of assigns clauses for abrupt exits from statements is different than the corresponding behavior for loops. Should it be? }
+%% TODO: Needs of clarification
+%% \marginpar{This behavior of assigns clauses for abrupt exits from statements is different than the corresponding behavior for loops. Should it be? }
 
 \begin{example} The clause \lstinline|assigns \nothing;| does not hold for that statement,
 even if the clause \lstinline|ensures x==\old(x);| holds: 


### PR DESCRIPTION
Related to #52 

@davidcok , It seems that you introduced that margin note in f83c99bca5bb2. The first commit of this pull request solves the form by removing it,

The note was: _This behavior of assigns clauses for abrupt exits from statements is different than the corresponding behavior for loops. Should it be?_

Perhaps we can follow the discussion about that question here ?