### PR TITLE
Adds section about the \ghost qualifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ HAS_FCLANG=$(shell if $(FRAMAC) -plugins | grep -q "Frama_Clang"; \
 GOOD=abrupt_termination.c advancedloopinvariants.c assert-tut.c		\
 assigns_array.c assigns.c assigns_list.c bsearch.c bsearch2.c		\
 cond_assigns.c div_lemma.c dowhile.c euclide.c exit.c extremum-tut.c	\
-extremum2-tut.c fact.c flag.c footprint.c ghostpointer.c		\
+extremum2-tut.c fact.c flag.c footprint.c 				\
 glob_var_masked.c glob_var_masked_sol.c global_invariant-tut.c		\
 incrstar.c initialized.c intlists.c isgcd.c isqrt.c listdecl.c		\
 listdef.c loopvariantnegative.c loop-frees.c loop_current.c		\
@@ -165,7 +165,7 @@ welltyped.c list-observer.c
 BAD=acsl_allocator.c arrayslice.c gen_code.c gen_spec_with_ghost.c	\
 gen_spec_with_model.c ghostcfg.c import.c invariants.c			\
 lexico.c listlengthdef.c listmodule.c                                   \
-modifier.c out_char.c sum2.c
+modifier.c out_char.c sum2.c ghost_qualifier.c ghostpointer.c
 
 ifeq ("$(HAS_FCLANG)","yes")
 CHECK_FILES=*.c *.cpp

--- a/ghost.tex
+++ b/ghost.tex
@@ -1,5 +1,8 @@
 \begin{syntax}
 
+  qualifier ::= C-qualifier ;
+  | "\ghost" ; only in ghost
+  \
   ghost-type-specifier ::= C-type-specifier ;
   | {logic-type} \
   logic-def ::= "ghost" ghost-declaration \

--- a/ghost_qualifier.c
+++ b/ghost_qualifier.c
@@ -1,22 +1,10 @@
-int a ;
-int * p ; // a pointer to non-const
-p = &a ;   // can only point to a non-const location
-
-//@ ghost int g ;
-//@ ghost int \ghost * pg ; // a pointer to ghost
-//@ ghost pg = &g ;          // can only point to a ghost location
-
-int const c = 42 ;
-
-int const* cp ;           // a pointer to a const location
-cp = &c ;                 // can point either to a const location
-cp = &a ;                 // or to a non const location
-
-//@ ghost int * other ;   // a pointer to a non-ghost location
-//@ ghost other = & a ;  // can point either to a non-ghost location
-//@ ghost other = & g ;  // or to a ghost location
-
-// a pointer to non-const location cannot point to a const location
-int * invalid = &c ;
-// a pointer to ghost location cannot point to a non-ghost location
-//@ ghost int \ghost * invalid = & a ;
+int a ;                      // a non-ghost location
+/*@ ghost
+  int* good = &a ;           // can be referenced by a pointer to non-ghost
+  int \ghost* bad = &a ;     // cannot be referenced by a pointer to ghost
+*/
+/*@ ghost
+  int g ;                    // a ghost location
+  int \ghost* good = &a ;    // can be referenced by a pointer to ghost
+  int * bad = &a ;           // cannot be referenced by a pointer to non-ghost
+*/

--- a/ghost_qualifier.c
+++ b/ghost_qualifier.c
@@ -1,10 +1,10 @@
-int a ;                      // a non-ghost location
+int a ;                       // a non-ghost location
 /*@ ghost
-  int* good = &a ;           // can be referenced by a pointer to non-ghost
-  int \ghost* bad = &a ;     // cannot be referenced by a pointer to ghost
+  int* good0 = &a ;           // can be referenced by a pointer to non-ghost
+  int \ghost* bad0 = &a ;     // cannot be referenced by a pointer to ghost
 */
 /*@ ghost
-  int g ;                    // a ghost location
-  int \ghost* good = &a ;    // can be referenced by a pointer to ghost
-  int * bad = &a ;           // cannot be referenced by a pointer to non-ghost
+  int g ;                     // a ghost location
+  int \ghost* good1 = &a ;    // can be referenced by a pointer to ghost
+  int * bad1 = &a ;           // cannot be referenced by a pointer to non-ghost
 */

--- a/ghost_qualifier.c
+++ b/ghost_qualifier.c
@@ -1,0 +1,22 @@
+int a ;
+int * p ; // a pointer to non-const
+p = &a ;   // can only point to a non-const location
+
+//@ ghost int g ;
+//@ ghost int \ghost * pg ; // a pointer to ghost
+//@ ghost pg = &g ;          // can only point to a ghost location
+
+int const c = 42 ;
+
+int const* cp ;           // a pointer to a const location
+cp = &c ;                 // can point either to a const location
+cp = &a ;                 // or to a non const location
+
+//@ ghost int * other ;   // a pointer to a non-ghost location
+//@ ghost other = & a ;  // can point either to a non-ghost location
+//@ ghost other = & g ;  // or to a ghost location
+
+// a pointer to non-const location cannot point to a const location
+int * invalid = &c ;
+// a pointer to ghost location cannot point to a non-ghost location
+//@ ghost int \ghost * invalid = & a ;

--- a/list-observer.c
+++ b/list-observer.c
@@ -4,10 +4,12 @@
   @ }
   @*/
 
-/*@ assigns ghost_trace;
-  @ ensures register: observed_trace == (\old(observed_trace) ^ [| a |]);
-  @*/
-void track(int a);
+/*@ ghost
+  /@ assigns ghost_trace;
+   @ ensures register: observed_trace == (\old(observed_trace) ^ [| a |]);
+   @/
+  void track(int a);
+*/
 
 /*@ requires empty_trace: observed_trace == \Nil;
   @ assigns ghost_trace;

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3451,7 +3451,7 @@ grammar are the following:
 \begin{figure}[t]
   \begin{cadre}
       \input{ghost.bnf}
-    \end{cadre}
+  \end{cadre}
   \caption{Grammar for ghost statements}
 \label{fig:gram:ghost}
 \end{figure}
@@ -3471,9 +3471,9 @@ program execution. This implies several conditions, including e.g.:
   non-ghost variables or fields.
 \item If a non-ghost C function is called in ghost code, it must not
   modify non-ghost variables or fields.
-\item If a structure has ghost fields, the \lstinline|sizeof| of the
+\item \notimplemented{If a structure has ghost fields, the \lstinline|sizeof| of the
   structure is the same as the structure without ghost fields. Also,
-  alignment of fields remains unchanged.
+  alignment of fields remains unchanged.}
 \item The control-flow graph of a function must not be altered by
   ghost statements. In particular, no ghost \lstinline|return| can appear
   in the body of a non-ghost function. Similarly, ghost
@@ -3503,6 +3503,27 @@ statically detected as ghost must be semantically ghost.
 \begin{example}
   The following example shows some invalid ghost statements:
   \listinginput{1}{ghostcfg.c}
+\end{example}
+
+The qualifier \lstinline|\ghost| can be used, in ghost code only, in declaration
+of a variable to state precisely in which memory (normal or ghost) its type
+belongs.
+
+As \lstinline|\ghost| is a qualifier, it obeys to the same typing rules except
+on two aspects. First, a variable declared in a ghost annotation (including
+ghost parameters) receives implicitly the \lstinline|\ghost| qualifier. Second,
+compared to the \lstinline|const| qualifier, the \lstinline|\ghost| qualifier
+follows the rules associated to the creation of a non-\lstinline|const| element.
+It is allowed to create a reference on \lstinline|\ghost| (non-\lstinline|const|)
+object only if this object is itself \lstinline|\ghost| (non-\lstinline|const|).
+On the opposite, creating a reference to a non-\lstinline|\ghost|
+(\lstinline|const|) object is allowed no matter if it is non-\lstinline|\ghost|
+(\lstinline|const|) or \lstinline|\ghost| (non-\lstinline|const|).
+
+\begin{example}
+  The following example shows simple uses of the \lstinline|\ghost| qualifier
+  and compares it to the use of the \lstinline|const| keyword.
+  \listinginput{1}{ghost_qualifier.c}
 \end{example}
 
 \paragraph{Differences between model variables and ghost variables}

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3507,22 +3507,19 @@ statically detected as ghost must be semantically ghost.
 
 The qualifier \lstinline|\ghost| can be used, in ghost code only, in declaration
 of a variable to state precisely in which memory (normal or ghost) its type
-belongs.
+belongs. Since it is a syntactic element, it is statically decidable.
 
-As \lstinline|\ghost| is a qualifier, it obeys to the same typing rules except
+Since \lstinline|\ghost| is a qualifier, it obeys to the same typing rules except
 on two aspects. First, a variable declared in a ghost annotation (including
 ghost parameters) receives implicitly the \lstinline|\ghost| qualifier. Second,
 compared to the \lstinline|const| qualifier, the \lstinline|\ghost| qualifier
-follows the rules associated to the creation of a non-\lstinline|const| element.
-It is allowed to create a reference on \lstinline|\ghost| (non-\lstinline|const|)
-object only if this object is itself \lstinline|\ghost| (non-\lstinline|const|).
-On the opposite, creating a reference to a non-\lstinline|\ghost|
-(\lstinline|const|) object is allowed no matter if it is non-\lstinline|\ghost|
-(\lstinline|const|) or \lstinline|\ghost| (non-\lstinline|const|).
+follows a stricter rule. When assigning a reference, the ghost qualification of
+the lvalue must exactly match the ghost qualification of the reference, meaning
+that a (non-)\lstinline|\ghost| memory location can only be reference by a pointer
+to a (non-)\lstinline|\ghost| memory location.
 
 \begin{example}
-  The following example shows simple uses of the \lstinline|\ghost| qualifier
-  and compares it to the use of the \lstinline|const| keyword.
+  The following example shows simple uses of the \lstinline|\ghost| qualifier.
   \listinginput{1}{ghost_qualifier.c}
 \end{example}
 


### PR DESCRIPTION
This PR adds the `\ghost` qualifier to the manual and explains its behavior.