### PR TITLE
Section 2.7.2: fixed typo; “ca be” → “can be”

### DIFF
--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -2696,7 +2696,7 @@ $i\neq j$, \lstinline|\separated(s$_i$,s$_j$)|.
 \end{itemize}
 
 Note that \lstinline|\separated| does not have a label argument. The separation of sets of locations
-ca be determined without reference to the content of the heap, so no reference to a heap state is needed.
+can be determined without reference to the content of the heap, so no reference to a heap state is needed.
 However the evaluation of each argument may depend on a heap state, so \lstinline|\at| expressions are often needed.
 
 


### PR DESCRIPTION
Dear ACSL folks,

The attached commit fixed a little typo in § _7.2.2 Separation_. An ’n’ was missing.

> “[…] locations ca**n** be determined […]”
