### PR TITLE
Clean up following v1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BNF_FILES=term.tex predicate.tex binders.tex fn_behavior.tex \
           list-gram.tex c-type-name.tex cpp-functional-gram.tex		\
           cpp-exceptionbehavior.tex cpp-default-values-syntax.tex	\
           cpp-class-invariants-fig.tex cpp-this.tex cpp-gram-pure.tex   \
-          cpp-casts.tex
+          cpp-casts.tex attribute.tex
 
 BNF_DEPS=$(BNF_FILES:.tex=.bnf)
 

--- a/assertions.tex
+++ b/assertions.tex
@@ -1,9 +1,18 @@
 \begin{syntax}
-  C-compound-statement ::= "{" C-declaration* C-statement* assertion+ "}"
-        \
-  C-statement ::= assertion C-statement \
-  assertion-kind ::= "assert" | clause-kind \
-  assertion ::= "/*@" assertion-kind pred ";" "*/" ;
-  | "/*@" "for" id ("," id)* ":" ;
-      assertion-kind pred ";" "*/" ;
+  C-compound-statement [Extension to the C \ifCPPnc{and C++} standard grammar for compound statements] ::=
+    "{" C-declaration* ;
+    C-statement* assertion+"}"
+  \
+  C-statement  [Extension to the C \ifCPPnc{and C++} standard grammar for statements] ::=
+  assertion ;
+  C-statement
+  \
+  assertion-kind ::= "assert" ; assertion
+  | clause-kind ; non-blocking assertion
+  \
+  assertion ::= "/*@" assertion-kind pred";" ;
+    "*/" ;
+  | "/*@" "for" id ("," id)*":" ;
+    assertion-kind pred";" ;
+    "*/"
 \end{syntax}

--- a/attribute.tex
+++ b/attribute.tex
@@ -1,0 +1,5 @@
+\begin{syntax}
+type-qualifier ::= C-type-qualifier | acsl-attribute
+\
+acsl-attribute ::= "/*@" id "*/"
+\end{syntax}

--- a/attribute.tex
+++ b/attribute.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-C-type-qualifier ::= C-type-qualifier | acsl-attribute
+C-type-qualifier [Extension to the C \ifCPPnc{and C++} standard grammar for type qualifiers]::= acsl-attribute
 \
-acsl-attribute ::= "/*@" id "*/"
+acsl-attribute ::= "/*@"[The identifier must be enclosed between /@ and @/ in ghost code] id "*/" ; implementation dependent attribute
 \end{syntax}

--- a/attribute.tex
+++ b/attribute.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
 C-type-qualifier [Extension to the C \ifCPPnc{and C++} standard grammar for type qualifiers]::= acsl-attribute
 \
-acsl-attribute ::= "/*@"[The identifier must be enclosed between /@ and @/ in ghost code] id "*/" ; implementation dependent attribute
+acsl-attribute ::= "/*@"[The identifier may be enclosed between /@ and @/ in ghost code] id "*/" ; implementation dependent attribute
 \end{syntax}

--- a/attribute.tex
+++ b/attribute.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-type-qualifier ::= C-type-qualifier | acsl-attribute
+C-type-qualifier ::= C-type-qualifier | acsl-attribute
 \
 acsl-attribute ::= "/*@" id "*/"
 \end{syntax}

--- a/changes.tex
+++ b/changes.tex
@@ -1,5 +1,10 @@
 \subsection{Version \acslversion}
 \begin{itemize}
+\item Slightly improve section~\ref{sec:attribute_annot}, that was a bit rushed into
+the last version
+\end{itemize}
+\subsection{Version 1.15}
+\begin{itemize}
 \item Add section~\ref{sec:ppimpl} for precising status of pre-processing
   directives and macros against specifications
 \item Introduction of the \lstinline|\ghost| qualifier (section~\ref{sec:ghost})

--- a/ghost.tex
+++ b/ghost.tex
@@ -1,52 +1,42 @@
 \begin{syntax}
 
-  C-type-qualifier ::= ; extended C standard
-    | "\ghost" ; only in ghost code
+  C-type-qualifier [Extension to the C \ifCPPnc{and C++} standard grammar for type qualifiers in ghost code only] ::= "\ghost" ; ghost qualifier
   \
-  C-type-specifier ::= ; extended C standard
-    | {logic-type}  ; only in ghost code
+  C-type-specifier [extension to the C \ifCPPnc{and C++} standard grammar for type specifiers in ghost code only] ::=
+    {logic-type}
   \
   logic-def ::= "ghost" C-declaration ;
   \
-  ghost-direct-declarator ::= C-direct-declarator ;
-  \
-  C-direct-declarator ::= ; extended C standard
-    | ghost-direct-declarator ; except in ghost code
+  C-direct-declarator [Extension to the C \ifCPPnc{and C++} standard grammar for direct declarators, except in ghost code]::=
+      C-direct-declarator ; function declarator
       "(" C-parameter-type-list? ;
       ")" "/*@" "ghost" "(" ;
-          ghost-parameter-type-list; ghost params
+          C-parameter-type-list; with ghost params
       ")" "*/";
   \
-  ghost-postfix-expression ::= C-postfix-expression ;
-  \
-  C-postfix-expression ::= ; extended C standard
-    | ghost-postfix-expression ; except in ghost code
+  C-postfix-expression [Extension to the C \ifCPPnc{and C++} standard grammar for postfix expressions, except in ghost code]::=
+      C-postfix-expression ; function call
       "(" C-argument-expression-list? ;
        ")" "/*@" "ghost" "(" ;
-           ghost-argument-expression-list; ghost args
+           C-argument-expression-list; with ghost args
        ")";
       "*/" ;
    \
-  ghost-statement ::= C-statement ;
-  \
-  C-statement ::= ; extended C standard
-    | "/*@" "ghost"; except in ghost code
-            ghost-statement+ ; ghost code
+  C-statement [Extension to the C \ifCPPnc{and C++} standard grammar for statements, except in ghost code] ::=
+      "/*@" "ghost";
+            C-statement+ ; ghost code
       "*/" ;
-    | "if" "(" C-expression ")"; except in ghost code
+    | "if" "(" C-expression ")";
        statement;
        "/*@" "ghost" ;
-             "else" ghost-statement ; ghost alternative
-        ghost-statement* ; unconditional code
+             "else" C-statement ; ghost alternative
+        C-statement* ; unconditional ghost code
       "*/"
   \
-  ghost-struct-declaration ::= C-struct-declaration ;
-  \
-  C-struct-declaration ::= ; extended C standard
-  | {"/*@" "ghost" }; except in ghost code
-          {ghost-struct-declaration} ; ghost field
-    {"*/"} ;
-
+  C-struct-declaration [Extension to the C \ifCPPnc{and C++} standard grammar for struct declarations, except in ghost code] ::=
+    {"/*@" "ghost" };
+          {C-struct-declaration} ; ghost field
+    {"*/"}
 \end{syntax}
 
 %%% Local Variables:

--- a/ghost.tex
+++ b/ghost.tex
@@ -1,40 +1,51 @@
 \begin{syntax}
 
-  C-type-qualifier ::= C-type-qualifier ;
-  | "\ghost" ; only in ghost
+  C-type-qualifier ::= ; extended C standard
+    | "\ghost" ; only in ghost code
   \
-  ghost-type-specifier ::= C-type-specifier ;
-  | {logic-type} \
-  logic-def ::= "ghost" ghost-declaration \
-  direct-declarator ::= C-direct-declarator ;
-    | direct-declarator ;
-    "(" C-parameter-type-list? ")";
-        "/*@" "ghost";
-          "(" ghost-parameter-type-list")";
-          "*/"; ghost args
-        \
-  postfix-expression ::= C-postfix-expression ;
-    | postfix-expression ;
-     "(" C-argument-expression-list? ")";
-     "/*@" "ghost" ;
-       "(" ghost-argument-expression-list ")";
-       "*/" ; call
-              ; with ghosts
-    \
-  statement ::= C-statement ;
-             | statements-ghost \
-  statements-ghost ::= "/*@" "ghost";
-                       ghost-statement+ "*/" \
-  ghost-selection-statement ::= C-selection-statement ;
-    | "if" "(" C-expression ")";
+  C-type-specifier ::= ; extended C standard
+    | {logic-type}  ; only in ghost code
+  \
+  logic-def ::= "ghost" C-declaration ;
+  \
+  ghost-direct-declarator ::= C-direct-declarator ;
+  \
+  C-direct-declarator ::= ; extended C standard
+    | ghost-direct-declarator ; except in ghost code
+      "(" C-parameter-type-list? ;
+      ")" "/*@" "ghost" "(" ;
+          ghost-parameter-type-list; ghost params
+      ")" "*/";
+  \
+  ghost-postfix-expression ::= C-postfix-expression ;
+  \
+  C-postfix-expression ::= ; extended C standard
+    | ghost-postfix-expression ; except in ghost code
+      "(" C-argument-expression-list? ;
+       ")" "/*@" "ghost" "(" ;
+           ghost-argument-expression-list; ghost args
+       ")";
+      "*/" ;
+   \
+  ghost-statement ::= C-statement ;
+  \
+  C-statement ::= ; extended C standard
+    | "/*@" "ghost"; except in ghost code
+            ghost-statement+ ; ghost code
+      "*/" ;
+    | "if" "(" C-expression ")"; except in ghost code
        statement;
-      "/*@" "ghost" "else";
-        ghost-statement+ ;
-        "*/" \
-
-  struct-declaration ::= C-struct-declaration ;
-  | {"/*@" "ghost" };
-    { struct-declaration "*/"} ; ghost field
+       "/*@" "ghost" ;
+             "else" ghost-statement ; ghost alternative
+        ghost-statement* ; unconditional code
+      "*/"
+  \
+  ghost-struct-declaration ::= C-struct-declaration ;
+  \
+  C-struct-declaration ::= ; extended C standard
+  | {"/*@" "ghost" }; except in ghost code
+          {ghost-struct-declaration} ; ghost field
+    {"*/"} ;
 
 \end{syntax}
 

--- a/libraries_modern.tex
+++ b/libraries_modern.tex
@@ -65,7 +65,7 @@ introduce the following logic functions:
 /*@
   @ logic integer \offset_min{L}<a>(a *p);
   @ logic integer \offset_max{L}<a>(a *p);
-  @/
+  @*/
 \end{listing}
 \end{notimplementedenv}
 

--- a/logic.tex
+++ b/logic.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-  C-external-declaration ::= "/*@" logic-def+ "*/"[These may appear as global \ifCPPnc{or class} declarations] ;
+  C-external-declaration [Extension to the C \ifCPPnc{and C++} standard grammar for external declarations as global \ifCPPnc{or class} declarations] ::= "/*@" logic-def+"*/"
   \
   logic-def ::= logic-const-def ;
           | logic-function-def ;
@@ -25,13 +25,13 @@
   \
   logic-function-def ::= "logic" \ifCPPnc#( "static" | "virtual" )?#;
   type-expr;
-  poly-id parameters "=";
-  term ";"
+  poly-id parameters;
+  "=" term ";"
   \
   logic-predicate-def ::=
   "predicate" \ifCPPnc#( "static" | "virtual" )?#;
-  poly-id parameters? "=";
-  pred ";"
+  poly-id parameters?;
+  "=" pred ";"
   \
   parameters ::= "(" parameter;
                  (, parameter)* ")"

--- a/loops.tex
+++ b/loops.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-  C-statement [Extension of the C standart for statements]::= "/*@" loop-annot "*/" ;
+  C-statement [Extension of the C \ifCPPnc{and C++} standard for statements]::= "/*@" loop-annot "*/" ;
   C-iteration-statement ;
   \
   loop-annot [empty loop annotations are forbidden] ::= loop-clause* loop-behavior* ;

--- a/loops.tex
+++ b/loops.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-  statement ::= "/*@" loop-annot "*/" ;
+  C-statement [Extension of the C standart for statements]::= "/*@" loop-annot "*/" ;
   C-iteration-statement ;
   \
   loop-annot [empty loop annotations are forbidden] ::= loop-clause* loop-behavior* ;

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3436,7 +3436,8 @@ ghost code, as mentioned in section~\ref{sec:gener-about-annot}).
 The grammar is given in Figure~\ref{fig:gram:ghost}, in which only the
 first form of annotation is used. In this figure, the \textit{C-*}
 non-terminals refer to the corresponding grammar rules of the ISO standard.
-The definition of some of them is extended in order to accept ACSL entensions with sometimes restrictions (only/except in ghost code).
+The definition of some of them is extended in order to accept ACSL entensions.
+Such extensions are sometimes only available in ghost code (e.g. use of logic types), or only in the C code (e.g. you can't use \lstinline|/*@ ghost| when already in ghost code). This is mentioned in the definition as well.
 
 The variations with respect to the C
 grammar are the following:

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3688,13 +3688,6 @@ and \lstinline|\valid_function(p)| holds if and only if
   \listinginput{1}{welltyped.c}
 \end{example}
 
-
-\section{Module constructions}
-
-\experimental
-
-how to encapsulate several functions...
-
 \section{Logic attribute annotations}
 \label{sec:attribute_annot}
 

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3435,11 +3435,8 @@ for one-line
 ghost code, as mentioned in section~\ref{sec:gener-about-annot}).
 The grammar is given in Figure~\ref{fig:gram:ghost}, in which only the
 first form of annotation is used. In this figure, the \textit{C-*}
-non-terminals refer to the corresponding grammar rules of the ISO standard,
-without any ACSL extension. Any non-terminal of the form
-\textit{ghost-non-term} for which no definition is given in the figure
-represents the corresponding \textit{C-non-term} entry, in which any
-\textit{entry} is substituted by \textit{ghost-entry}.
+non-terminals refer to the corresponding grammar rules of the ISO standard.
+The definition of some of them is extended in order to accept ACSL entensions with sometimes restrictions (only/except in ghost code).
 
 The variations with respect to the C
 grammar are the following:

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3693,7 +3693,19 @@ and \lstinline|\valid_function(p)| holds if and only if
 
 \experimental
 
-These are annotations allowing to add attributes on variables, like regular C attributes (const, volatile, restrict).
+These are annotations allowing to add attributes on variables,
+like regular C qualifiers (\texttt{const}, \texttt{volatile}, \texttt{restrict}),
+or GNU \texttt{\_\_attribute\_\_}. They are defined in figure~\ref{fig:gram:attr}.
+
+\begin{figure}[htb]
+\begin{cadre}
+\input{attribute.bnf}
+\end{cadre}
+\caption{Grammar for \NAME attributes}
+\label{fig:gram:attr}
+\end{figure}
+
+Supported attributes are implementation dependent.
 
 \section{Preprocessing for \NAME}
 \label{sec:ppimpl}

--- a/st_contracts.tex
+++ b/st_contracts.tex
@@ -1,5 +1,5 @@
 \begin{syntax}
-  statement ::= "/*@" statement-contract "*/" statement
+  C-statement [Extension to the C \ifCPPnc{and C++} standard grammar for statements] ::= "/*@" statement-contract "*/" C-statement
   \
   statement-contract [empty contracts are forbidden] ::= ("for" id ("," id)* ":")? requires-clause* ;
     simple-clause-stmt* named-behavior-stmt* ;


### PR DESCRIPTION
- Remove ex-section 2.16 that was redundant with 2.6.11
- slightly expand new section 2.16 (ACSL attributes) that was nearly empty when committed.

Issue reported initially by @zilbuz