### PR TITLE
more robust command to determine mode when defining listing's style

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,19 @@
+name: compile
+
+on: [push]
+
+jobs:
+  compile:
+    name: compile the manuals
+    runs-on: ubuntu-latest
+    steps:
+      - name: install needed packages
+        run: sudo apt update &&  DEBIAN_FRONTEND=noninteractive sudo --preserve-env=DEBIAN_FRONTEND apt install -y make texlive-full latexmk ocaml-nox
+      - name: retrieve sources
+        uses: actions/checkout@v2
+      - name: compile acsl manual
+        run: make acsl.pdf
+      - name: compile acsl++ manual
+        run: make acslpp.pdf
+      - name: check grammar coherence
+        run: make grammar-check

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,5 +15,13 @@ jobs:
         run: make acsl.pdf
       - name: compile acsl++ manual
         run: make acslpp.pdf
+      - name: archive log and pdf
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            acsl.log
+            acslpp.log
+            acsl.pdf
+            acslpp.pdf
       - name: check grammar coherence
         run: make grammar-check

--- a/Makefile
+++ b/Makefile
@@ -248,13 +248,9 @@ tutorial-check: acsl-mini-tutorial.tex
 	   exit 1; \
         else echo "All examples from the tutorial are accepted. Good!"; \
         fi
-
-BUILTINS=real integer string character id \
-         function-contract global-invariant type-invariant logic-specification \
-         assertion loop-annotation statement-contract \
-         ghost-code
-
 endif
+
+BUILTINS=real integer string character id
 
 grammar-check: transf
 	./transf -check $(addprefix -builtin ,$(BUILTINS)) $(BNF_FILES)

--- a/frama-c-book.cls
+++ b/frama-c-book.cls
@@ -147,8 +147,8 @@
 \definecolor{lstspecial}{rgb}{0.2,0.6,0.0}
 \definecolor{lstfile}{gray}{0.85}
 \newcommand{\lstbrk}{\mbox{$\color{blue}\scriptstyle\cdots$}}
-\def\lp@basic{\ifmmode\normalfont\mathtt\mdseries\small\else\normalfont\ttfamily\mdseries\small\fi}
-\def\lp@inline{\ifmmode\normalfont\mathtt\scriptstyle\else\normalfont\ttfamily\mdseries\small\fi}
+\def\lp@basic{\TextOrMath{\normalfont\ttfamily\mdseries\small}{\normalfont\mathtt\mdseries\small}}
+\def\lp@inline{\TextOrMath{\normalfont\ttfamily\mdseries\small}{\normalfont\mathtt\scriptstyle}}
 \def\lp@keyword{}
 \def\lp@special{\color{lstfg}}
 \def\lp@comment{\normalfont\ttfamily\mdseries}
@@ -159,7 +159,7 @@
   basicstyle=\lp@inline,%
   identifierstyle=\lp@ident,%
   commentstyle=\lp@comment,%
-  keywordstyle={\ifmmode\mathsf\else\sffamily\fi},%
+  keywordstyle={\TextOrMath{\sffamily}{\mathsf}},%
   keywordstyle=[2]\lp@special,%
   stringstyle=\lp@string,%
   emphstyle=\lp@ident\underbar,%

--- a/ghost.tex
+++ b/ghost.tex
@@ -27,7 +27,7 @@
             C-statement+ ; ghost code
       "*/" ;
     | "if" "(" C-expression ")";
-       statement;
+       C-statement;
        "/*@" "ghost" ;
              "else" C-statement ; ghost alternative
         C-statement* ; unconditional ghost code

--- a/term.tex
+++ b/term.tex
@@ -4,7 +4,7 @@
        | real ; (lexical) real constants
        | string ; (lexical) string constants
        | character ; (lexical) character constants
-       \ 
+       \
   bin-op ::= "+" | "-" | "*" | "/" | "%" ;
        | "==" | "!=" | "<=" | ">=" | ">" | "<" ;
        | "&&" | "||" | "^^"  ; boolean operations


### PR DESCRIPTION
Apparently `\ifmmode` was too fragile, and started to break in some TeX installations. `\TextOrMath` is a LaTeX macro that is normally more robust.