### PR TITLE
Figure 2.8: Remove duplicate grammar rule for range.

### DIFF
--- a/loc.tex
+++ b/loc.tex
@@ -1,6 +1,4 @@
 \begin{syntax}
-  range ::= term? ".." term? ;
-       \
   tset ::= "\empty" ; empty set
        | tset "->" id ;
        | tset "." id ;


### PR DESCRIPTION
There are two identical rules for ranges in the grammar for sets of memory locations. This PR removes one of them.