### PR TITLE
Generate fc_version for acsl-implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ main.pdf
 /acsl-mini-tutorial.pdf
 /cpp-main.pdf
 /acslpp-implementation.pdf
+/fclang_version.tex

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ main.pdf
 /acslpp-implementation.tex
 /framacversion.tex
 /acsl-mini-tutorial.tex
+/fc_version.tex
 /*-tut.c
 /pp
 /pp.ml

--- a/Makefile
+++ b/Makefile
@@ -108,32 +108,34 @@ acslpp-implementation.pdf: fc_version.tex fclang_version.tex
 %.pdf: %.tex $(DEPS) $(BNF_DEPS)
 	latexmk -silent -pdf $<
 
-SHORT_VERSION ?= ../../VERSION
-HAS_SHORT_VERSION:=$(shell if test -f $(SHORT_VERSION); then echo yes; else echo no; fi)
+FC_VERSION_FILE ?= ../../VERSION
+HAS_FC_VERSION:=$(shell if test -f $(FC_VERSION); then echo yes; else echo no; fi)
 
 FCLANG_VERSION_FILE?=../../src/plugins/frama-clang/MAKEFILE
-HAS_FCLANG:=$(shell if test -f $(FCLANG_VERSION_FILE); then echo yes; else echo no; fi)
+HAS_FCLANG_VERSION:=$(shell if test -f $(FCLANG_VERSION_FILE); then echo yes; else echo no; fi)
 
-ifneq ("$(HAS_SHORT_VERSION)","yes")
+ifneq ("$(HAS_FC_VERSION)","yes")
 
 fc_version.tex: Makefile
-	@echo "Cannot get the Frama-C version out of frama-c doc directory"
-	@echo "Generating a joker version number for implementation"
+	@echo "WARNING: Cannot find $(FC_VERSION_FILE)"
+	@echo "         Generating a joker version number for implementation"
+	@echo "         Consider setting environment variable FC_VERSION_FILE"
 	@rm -f $@
 	@printf '\\newcommand{\\fcversion}{XX.X}\n' > $@
 
 else
 
-fc_version.tex: Makefile $(SHORT_VERSION)
+fc_version.tex: Makefile $(FC_VERSION_FILE)
 	@rm -f $@
-	@printf '\\newcommand{\\fcversion}{$(shell cat $(SHORT_VERSION))}\n' > $@
+	@printf '\\newcommand{\\fcversion}{$(shell cat $(FC_VERSION_FILE))}\n' > $@
 
 endif
 
-ifneq ("$(HAS_FCLANG)","yes")
+ifneq ("$(HAS_FCLANG_VERSION)","yes")
 fclang_version.tex: Makefile
-	@echo "Cannot find $(FCLANG_VERSION_FILE)."
-	@echo "Consider setting FCLANG_VERSION_FILE to an appropriate file"
+	@echo "WARNING: Cannot find $(FCLANG_VERSION_FILE)."
+	@echo "         Generating a joker version number for implementation"
+	@echo "         Consider setting environment variable FCLANG_VERSION_FILE"
 	@rm -f $@
 	@printf '\\newcommand{\\fclangversion}{YY.Y}\n' > $@
 else

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,28 @@ $(PDF_OUTPUTS): %.pdf: main.tex $(DEPS) $(BNF_DEPS)
 
 $(PDF_OUTPUTS_CPP): $(DEPS_CPP)
 
+acsl-implementation.pdf: fc_version.tex
 %.pdf: %.tex $(DEPS) $(BNF_DEPS)
 	latexmk -silent -pdf $<
+
+SHORT_VERSION ?= ../../VERSION
+HAS_SHORT_VERSION:=$(shell if test -f $(SHORT_VERSION); then echo yes; else echo no; fi)
+
+ifneq ("$(HAS_SHORT_VERSION)","yes")
+
+fc_version.tex:
+	@echo "Cannot get the Frama-C version out of frama-c doc directory"
+	@echo "Generating a joker version number for implementation"
+	@rm -f $@
+	@printf '\\newcommand{\\fcversion}{XX.X}\n' > $@
+
+else
+
+fc_version.tex: $(SHORT_VERSION)
+	@rm -f $@
+	@printf '\\newcommand{\\fcversion}{$(shell cat $(SHORT_VERSION))}\n' > $@
+
+endif
 
 pp: pp.ml
 	ocamlopt -o $@ str.cmxa $^

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,16 @@ HAS_FC_VERSION:=$(shell if test -f $(FC_VERSION); then echo yes; else echo no; f
 FCLANG_VERSION_FILE?=../../src/plugins/frama-clang/MAKEFILE
 HAS_FCLANG_VERSION:=$(shell if test -f $(FCLANG_VERSION_FILE); then echo yes; else echo no; fi)
 
+# always regenerate the version files, as their content depends on the
+# value of Make variables, which we can't really take into account for
+# dependencies (at least not easily)
+# if the content is unchanged, latexmk will detect it anyway.
+
+.PHONY: fc_version.tex fclang_version.tex
+
 ifneq ("$(HAS_FC_VERSION)","yes")
 
-fc_version.tex: Makefile
+fc_version.tex:
 	@echo "WARNING: Cannot find $(FC_VERSION_FILE)"
 	@echo "         Generating a joker version number for implementation"
 	@echo "         Consider setting environment variable FC_VERSION_FILE"
@@ -125,14 +132,14 @@ fc_version.tex: Makefile
 
 else
 
-fc_version.tex: Makefile $(FC_VERSION_FILE)
+fc_version.tex:
 	@rm -f $@
 	@printf '\\newcommand{\\fcversion}{$(shell cat $(FC_VERSION_FILE))}\n' > $@
 
 endif
 
 ifneq ("$(HAS_FCLANG_VERSION)","yes")
-fclang_version.tex: Makefile
+fclang_version.tex:
 	@echo "WARNING: Cannot find $(FCLANG_VERSION_FILE)."
 	@echo "         Generating a joker version number for implementation"
 	@echo "         Consider setting environment variable FCLANG_VERSION_FILE"
@@ -142,7 +149,7 @@ else
 FCLANG_VERSION:=$(shell grep -e FCLANG_VERSION= $(FCLANG_VERSION_FILE) | \
                          sed -e 's/[^=]*=\(.*\)/\1/')
 
-fclang_version.tex: Makefile $(FCLANG_VERSION_FILE)
+fclang_version.tex:
 	@rm -f $@
 	@printf '\\newcommand{\\fclangversion}{$(FCLANG_VERSION)}' > $@
 endif

--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,14 @@
 
 \input{common}
 \input{version}
-\iftoggle{PrintImplementationRq}{\input{fc_version.tex}}{}
+\iftoggle{PrintImplementationRq}{
+  \input{fc_version.tex}
+  \iftoggle{isCPP}{
+    \input{fclang_version.tex}
+  }
+  {}
+}
+{}
 
 \newcommand{\version}{\iftoggle{isCPP}{\acslppversion}{\acslversion}}
 

--- a/main.tex
+++ b/main.tex
@@ -6,6 +6,8 @@
 
 \input{common}
 \input{version}
+\iftoggle{PrintImplementationRq}{\input{fc_version.tex}}{}
+
 \newcommand{\version}{\iftoggle{isCPP}{\acslppversion}{\acslversion}}
 
 \begin{document}
@@ -64,7 +66,7 @@ $^4$ LRI, Univ Paris-Sud, CNRS, Orsay, F-91405
   which received funding from the European Union's 2020
   Research and Innovation Program under grant agreement
   No. 731453.
-  
+
   It builds on prior work supported by the ANR project CAT
   (ANR-05-RNTL-0030x), by the ANR CIFRE contract 2005/973,
   by the ANR project U3CAT (08-SEGI-0210xx), and the ANR PICF
@@ -141,16 +143,16 @@ $^4$ LRI, Univ Paris-Sud, CNRS, Orsay, F-91405
     program state at the beginning of the call, including the
     current values for the function parameters. The \emph{post-state}
     denotes the program state at the return of the call.
-    
+
     For a statement annotation, the \emph{pre-state} denotes the
     program state just prior to the annotation statement; the
     \emph{post-state}
-    denotes the program state immediately after execution of the annotated statement (which may be a block statement).  
-    
+    denotes the program state immediately after execution of the annotated statement (which may be a block statement).
+
     For a statement annotation, the \emph{pre-state} denotes the
     program state just prior to the annotation statement; the
     \emph{post-state}
-    denotes the program state immediately after execution of the annotated statement (which may be a block statement).  
+    denotes the program state immediately after execution of the annotated statement (which may be a block statement).
 
 \item[function behavior] \index{function behavior} \indextt{behavior}
 

--- a/version.tex
+++ b/version.tex
@@ -1,3 +1,2 @@
 \newcommand{\acslversion}{1.17} %% Version of ACSL document
 \newcommand{\acslppversion}{0.1.1} %% Version of ACSL++ document
-\newcommand{\fclangversion}{0.0.9} %% Version of Frama-Clang software

--- a/version.tex
+++ b/version.tex
@@ -1,4 +1,3 @@
 \newcommand{\acslversion}{1.17} %% Version of ACSL document
 \newcommand{\acslppversion}{0.1.1} %% Version of ACSL++ document
-\newcommand{\fcversion}{23.0} %% Version of Frama-C
 \newcommand{\fclangversion}{0.0.9} %% Version of Frama-Clang software


### PR DESCRIPTION
Generate Frama-C version file instead of having to update the file ourselves. If the version cannot be generated (acsl is not in the doc directory of Frama-C), a joker version is generated (XX.X).