### PR TITLE
remove logic attribute annotations

### DIFF
--- a/changes.tex
+++ b/changes.tex
@@ -1,3 +1,8 @@
+\subsection{Version \version}
+\begin{itemize}
+\item Remove experimental and barely used Logic attribute annotations.
+Use standard C attributes instead.
+\end{itemize}
 \subsection{Version 1.21}
 \begin{itemize}
 \item More precise definition of pre- and post-state of a function contract
@@ -31,7 +36,8 @@ clause with respect to \lstinline|complete| and \lstinline|disjoint| clauses
 \end{itemize}
 \subsection{Version 1.16}
 \begin{itemize}
-\item Slightly improve section~\ref{sec:attribute_annot}, that was a bit rushed into
+\item Slightly improve section on logic attribute annotations
+(removed in Version \version), that was a bit rushed into
 the last version
 \item Introduce \lstinline|check| and \lstinline|admit| clause kinds
 (sections~\ref{sec:check-admit-clauses}, \ref{sec:assertions},

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -3841,29 +3841,9 @@ and \lstinline|\valid_function(p)| holds if and only if
   \listinginput{1}{welltyped.c}
 \end{example}
 
-\section{Logic attribute annotations}
-\label{sec:attribute_annot}
-
-\experimental
-
-These are annotations allowing to add attributes on variables,
-like regular C qualifiers (\texttt{const}, \texttt{volatile}, \texttt{restrict}),
-or GNU \texttt{\_\_attribute\_\_}. They are defined in figure~\ref{fig:gram:attr}.
-
-\begin{figure}[htb]
-\begin{cadre}
-\input{attribute.bnf}
-\end{cadre}
-\caption{Grammar for \NAME attributes}
-\label{fig:gram:attr}
-\end{figure}
-
-Supported attributes are implementation dependent.
-
 \section{Preprocessing for \NAME}
 \label{sec:ppimpl}
 \input{preprocessing.tex}
-
 
 \ifCPP{
 \section{Questions and items to consider adding}

--- a/version.tex
+++ b/version.tex
@@ -1,2 +1,2 @@
-\newcommand{\acslversion}{1.21} %% Version of ACSL document
+\newcommand{\acslversion}{1.21+dev} %% Version of ACSL document
 \newcommand{\acslppversion}{0.1.1} %% Version of ACSL++ document


### PR DESCRIPTION
remove logic attribute annotations: feature was barely used, and standard C attributes can be introduced instead.