### PR TITLE
Allow for predicates as conditionals in ternary conditions

### DIFF
--- a/changes.tex
+++ b/changes.tex
@@ -1,4 +1,8 @@
 \subsection{Version \version}
+  \item Allow for predicates as conditionals in ternary conditions (\ref{sec:expressions}).
+\end{itemize}
+
+\subsection{Version 1.23}
 \begin{itemize}
   \item Clarify semantics of \lstinline|\valid(_read)| (Section~\ref{subsec:memory}).
   \item Add \lstinline|\aligned| builtin (Section~\ref{subsec:memory}).

--- a/speclang_modern.tex
+++ b/speclang_modern.tex
@@ -165,12 +165,10 @@ With respect to C pure expressions, the additional constructs are as follows:
     expression \lstinline|$e_1$|; \lstinline|$x$| can then be used in expression
     \lstinline|$e_2$|.
 
-\item[Conditional] \lstinline|$c$ ? $e_1$ : $e_2$|. There is a subtlety
-  here: the condition may be either a boolean term or a predicate.  In
-  case of a predicate, the two branches must be also predicates, so
-  that this construct acts as a connective with the following
-  semantics: \lstinline|$c$ ? $e_1$ : $e_2$| is equivalent to
-  \lstinline|($c$ ==> $e_1$) && (! $c$ ==> $e_2$)|.
+\item[Conditional] \lstinline|$c$ ? $e_1$ : $e_2$|. The condition $c$ may be
+	either a boolean term or a predicate. If $e_1$ and $e_2$ are predicates,
+	then this construct is equivalent to
+	\lstinline|($c$ ==> $e_1$) && (! $c$ ==> $e_2$)|.
 
 \item[Syntactic naming] \lstinline|id : e| is a term or a predicate
   equivalent to $e$. It is different from local naming with \lstinline|\let|:

--- a/term.tex
+++ b/term.tex
@@ -32,6 +32,7 @@
        | ident "(" term ("," term)* ")" ; function application
        | "(" term ")" ; parentheses
        | term "?" term ":" term ; ternary condition
+       | pred "?" term ":" term;
        | "\let" id "=" term ";" term ; local binding
        | "sizeof" "(" term ")" ;
        | "sizeof" "(" C-type-expr ")" ;


### PR DESCRIPTION
In Frama-C, for the constructors Pif and Tif, the conditionals are now represented as predicates.